### PR TITLE
Add Adobe analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Script from "next/script"
 import Alert from "@/core/blocks/alert/aler"
 import Consent from "@/core/blocks/consent/consent"
 import Footer from "@/core/blocks/footer"
@@ -34,6 +35,18 @@ export default function RootLayout({
           <Consent />
           <Footer />
         </ThemeProvider>
+
+        <Script id="data-layer">
+          {`window["dataLayer"] = {
+            "pageName":"seb.io",
+            "pagetype":"StandardPage",
+            "language":"en",
+            "environment":"prod",
+            "project":"green",
+            "website":"seb.io",
+          };`}
+        </Script>
+        <Script src="https://content.seb.se/dsc/da/launch/public/30e54a9d6c99/f9d07ef22744/launch-89d260357525.min.js" />
       </body>
     </html>
   )


### PR DESCRIPTION
Initial setup for Adobe Analytics. We may need to add more things, but hopefully this should be enough to start sending data.

I figure that we merge it straight to `main`, so we don't pollute with data from `staging`